### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/claudioromao/52772ea2-dbcc-4227-a5f0-9ec7ef348947/affde0d7-48e2-4687-8f31-230fe7037eb0/_apis/work/boardbadge/a7af154a-e035-42dd-a6a2-eaee79fab7ab)](https://dev.azure.com/claudioromao/52772ea2-dbcc-4227-a5f0-9ec7ef348947/_boards/board/t/affde0d7-48e2-4687-8f31-230fe7037eb0/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#439](https://dev.azure.com/claudioromao/52772ea2-dbcc-4227-a5f0-9ec7ef348947/_workitems/edit/439). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.